### PR TITLE
fix check subscription exists before unsubscribing

### DIFF
--- a/lib/ngx-drop/file-drop.component.ts
+++ b/lib/ngx-drop/file-drop.component.ts
@@ -151,7 +151,9 @@ export class FileComponent {
   }
 
   ngOnDestroy() {
-    this.subscription.unsubscribe();
+    if(this.subscription) {
+      this.subscription.unsubscribe();
+    }
   }
 }
 


### PR DESCRIPTION
This was creating a error where no interaction had been made before ngOnDestroy was called.