### PR TITLE
Allow angular 4 & 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,6 @@
     "protractor": "~5.1.0",
     "ts-node": "~2.0.0",
     "tslint": "~4.5.0",
-    "typescript": "2.4.2"
+    "typescript": ">=2.1.0 <2.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-file-drop",
-  "version": "1.0.17",
+  "version": "1.0.15",
   "license": "MIT",
   "scripts": {
     "ng": "ng",
@@ -29,18 +29,18 @@
     "url": "https://github.com/georgipeltekov/ngx-file-drop.git"
   },
   "dependencies": {
-    "@angular/common": "^4.0.0",
-    "@angular/compiler": "^4.0.0",
-    "@angular/core": "^4.0.0",
-    "@angular/platform-browser": "^4.0.0",
-    "@angular/platform-browser-dynamic": "^4.0.0",
-    "@angular/router": "^4.0.0",
+    "@angular/common": ">=4.00 <6.0.0",
+    "@angular/compiler": ">=4.00 <6.0.0",
+    "@angular/core": ">=4.00 <6.0.0",
+    "@angular/platform-browser": ">=4.00 <6.0.0",
+    "@angular/platform-browser-dynamic": ">=4.00 <6.0.0",
+    "@angular/router": ">=4.00 <6.0.0",
     "rxjs": "^5.1.0",
     "zone.js": "^0.8.4"
   },
   "devDependencies": {
-    "@angular/cli": "1.0.2",
-    "@angular/compiler-cli": "^4.0.0",
+    "@angular/cli": "1.4.9",
+    "@angular/compiler-cli": ">=4.00 <6.0.0",
     "@types/jasmine": "2.5.38",
     "@types/node": "~6.0.60",
     "codelyzer": "~2.0.0",
@@ -55,6 +55,6 @@
     "protractor": "~5.1.0",
     "ts-node": "~2.0.0",
     "tslint": "~4.5.0",
-    "typescript": "~2.2.0"
+    "typescript": "2.4.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-file-drop",
-  "version": "1.0.15",
+  "version": "1.0.17",
   "license": "MIT",
   "scripts": {
     "ng": "ng",


### PR DESCRIPTION
Allowing a wider range of angular versions. >=4.0.0 <6.0.0. 

@georgipeltekov based on your comment in https://github.com/georgipeltekov/ngx-file-drop/issues/17 i have made a revised pull request. Is this more to your liking?