### PR TITLE
using a workaround to enable getting files when no webkitGetAsEntry

### DIFF
--- a/src/lib/ngx-drop/file-drop.component.ts
+++ b/src/lib/ngx-drop/file-drop.component.ts
@@ -85,14 +85,23 @@ export class FileComponent implements OnDestroy {
         }
       }
       if (entry === null) {
-        continue;
-      }
-      
-      if (entry.isFile) {
-        const toUpload: UploadFile = new UploadFile(entry.name, entry);
+        const file = event.dataTransfer.files[i];
+        entry = {
+          name: file.name,
+          resultFile: file,
+          file: function(fileProcess) {
+                fileProcess(this.resultFile);
+          }
+        }
+        const /** @type {?} */ toUpload = new UploadFile(entry.name, entry);
         this.addToQueue(toUpload);
-      } else if (entry.isDirectory) {
-        this.traverseFileTree(entry, entry.name);
+      } else {
+        if (entry.isFile) {
+            const toUpload: UploadFile = new UploadFile(entry.name, entry);
+            this.addToQueue(toUpload);
+        } else if (entry.isDirectory) {
+            this.traverseFileTree(entry, entry.name);
+        }
       }
     }
 

--- a/src/lib/ngx-drop/file-drop.component.ts
+++ b/src/lib/ngx-drop/file-drop.component.ts
@@ -84,7 +84,7 @@ export class FileComponent implements OnDestroy {
           entry = event.dataTransfer.files[i].webkitGetAsEntry();
         }
       }
-      if (entry === null) {
+      if (!entry) {
         const file = event.dataTransfer.files[i];
         entry = {
           name: file.name,


### PR DESCRIPTION
as the webkitGetAsEntry method is not supported from some browsers just calling continue will not drop the files in the drop down area, so my proposal is to create an entry object in that case from which we can create an upload file so that the files will be passed to the onFileDrop event and they can be processed using:
```javascript
public dropped(event: UploadEvent) {
	event.files.forEach((file: any) => {
		file.fileEntry.file(info => {
			console.log(info.name);
		});
	});
}
```
This way the drag and drop works on Safari.