### PR TITLE
Fix global listeners to be initialized always

### DIFF
--- a/src/lib/ngx-drop/file-drop.component.ts
+++ b/src/lib/ngx-drop/file-drop.component.ts
@@ -44,13 +44,13 @@ export class FileComponent implements OnDestroy {
   ) {
     if (!this.customstyle) {
       this.customstyle = 'drop-zone';
-      this.globalStart = this.renderer.listen('document', 'dragstart', (evt) => {
-        this.globalDisable = true;
-      });
-      this.globalEnd = this.renderer.listen('document', 'dragend', (evt) => {
-        this.globalDisable = false;
-      });
     }
+    this.globalStart = this.renderer.listen('document', 'dragstart', (evt) => {
+      this.globalDisable = true;
+    });
+    this.globalEnd = this.renderer.listen('document', 'dragend', (evt) => {
+      this.globalDisable = false;
+    });
   }
   
   public onDragOver(event: Event): void {


### PR DESCRIPTION
This change fixes the problem that the listeners added in #55 are not initialized if custom style is applied.