### PR TITLE
Allow drag events to be ignored that originate from document when applying custom styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 ## Change Log
+### [3.0.2](https://github.com/georgipeltekov/ngx-file-drop/compare/v3.0.1...v3.0.2) (2018-04-29)
+* Allow drag events to be ignored that originate from document (introduced in 3.0.1) even if using custom styles
+
+### [3.0.1](https://github.com/georgipeltekov/ngx-file-drop/compare/v3.0.0...v3.0.1) (2018-04-25)
+* Conditionally Disable Dropzone and Ignore DragEvents that initiate from within the browser document
+
 ### [3.0.0](https://github.com/georgipeltekov/ngx-file-drop/compare/v2.0.5...v3.0.0) (2018-03-15)
 * Added better typescript types
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-file-drop",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/lib/ngx-drop/file-drop.component.ts
+++ b/src/lib/ngx-drop/file-drop.component.ts
@@ -44,13 +44,13 @@ export class FileComponent implements OnDestroy {
   ) {
     if (!this.customstyle) {
       this.customstyle = 'drop-zone';
-      this.globalStart = this.renderer.listen('document', 'dragstart', (evt) => {
-        this.globalDisable = true;
-      });
-      this.globalEnd = this.renderer.listen('document', 'dragend', (evt) => {
-        this.globalDisable = false;
-      });
     }
+    this.globalStart = this.renderer.listen('document', 'dragstart', (evt) => {
+      this.globalDisable = true;
+    });
+    this.globalEnd = this.renderer.listen('document', 'dragend', (evt) => {
+      this.globalDisable = false;
+    });
   }
   
   public onDragOver(event: Event): void {


### PR DESCRIPTION
This change fixes the problem that the listeners added in #55 are not initialized if custom style is applied.
