### PR TITLE
Fix for big, nested folder structure

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-file-drop",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/lib/ngx-drop/file-drop.component.ts
+++ b/src/lib/ngx-drop/file-drop.component.ts
@@ -37,6 +37,8 @@ export class FileComponent implements OnDestroy {
   globalStart: Function;
   globalEnd: Function;
 
+  numOfActiveReadEntries = 0
+
   constructor(
     private zone: NgZone,
     private renderer: Renderer
@@ -122,10 +124,12 @@ export class FileComponent implements OnDestroy {
 
       const timerObservable = timer(200, 200);
       this.subscription = timerObservable.subscribe(t => {
-        if (this.stack.length === 0) {
+        if (this.files.length > 0) {
           this.onFileDrop.emit(new UploadEvent(this.files));
           this.files = [];
-          this.subscription.unsubscribe();
+          if (this.numOfActiveReadEntries === 0) {
+            this.subscription.unsubscribe();
+          }
         }
       });
     }
@@ -148,6 +152,7 @@ export class FileComponent implements OnDestroy {
       const thisObj = this;
 
       const readEntries = function () {
+        thisObj.numOfActiveReadEntries++
         dirReader.readEntries(function (res) {
           if (!res.length) {
             // add empty folders
@@ -171,6 +176,7 @@ export class FileComponent implements OnDestroy {
             entries = entries.concat(res);
             readEntries();
           }
+          thisObj.numOfActiveReadEntries--
         });
       };
 


### PR DESCRIPTION
Hi,
I added a variable numOfActiveReadEntries, this variable counts the number of active dirReader.readEntries(function (res) { .... } ). Only when numOfActiveReadEntries===0 it will unsubscribed from the subscription. 
Sometimes it could happen that the stack.length === 0, but there are still active readEntries(...) and files.length === 0. So an empty array would have been emitted. Thats why I changed the if condition to if (this.files.length > 0).

Best,
Philipp