### PR TITLE
Support patch-level differences for zone.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@angular/platform-browser": "^7.0.0",
     "@angular/platform-browser-dynamic": "^7.0.0",
     "rxjs": "^6.3.3",
-    "zone.js": "0.8.26"
+    "zone.js": "~0.8.26"
   },
   "devDependencies": {
     "@angular/core": "^7.0.0",


### PR DESCRIPTION
Allow patch-level upgrades for zone.js to align with [how @angular/core has their dependency specified](https://github.com/angular/angular/blob/master/packages/core/package.json).  This will get rid of an angular CLI update warning that requires a --force flag.

Admittedly, this isn't a huge issue, will just make upgrading angular a bit easier.