### PR TITLE
Clear file input element after each change

### DIFF
--- a/src/lib/ngx-drop/file-drop.component.html
+++ b/src/lib/ngx-drop/file-drop.component.html
@@ -5,8 +5,8 @@
         <ng-content></ng-content>
         {{headertext}}
         <div *ngIf="showBrowseBtn">
-            <input type="file" #fileSelector [accept]="accept" (change)="uploadFiles($event)" multiple style="display: none;" />
+            <input type="file" #fileSelector class="ngx-file-drop__file-input" [accept]="accept" (change)="uploadFiles($event)" multiple />
             <input type="button" [className]="customBtnStyling" value="{{browseBtnLabel}}" (click)="onBrowseButtonClick($event)" />
-        </div>        
+        </div>
     </div>
 </div>

--- a/src/lib/ngx-drop/file-drop.component.scss
+++ b/src/lib/ngx-drop/file-drop.component.scss
@@ -16,3 +16,7 @@
 .over{
   background-color: rgba(147, 147, 147, 0.5);
 }
+
+.ngx-file-drop__file-input {
+  display: none;
+}


### PR DESCRIPTION
This is a fix to empty the file input element after each change so that the same file can be uploaded multiple times in a row.
Currently it is not possible to use the file input multiple times with the same file since adding the same file again does not trigger the change event on the element (since nothing changed).
This is relevant when using ngx-file-drop for example in a custom reactive form control where the control can be reset / cleared and the user wants to use the ngx-file-drop file input again with the same file.