### PR TITLE
Code cleanup and consistent naming scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,9 +115,9 @@ export class AppComponent {
 ```
 ```HTML
 <div class="center">
-    <file-drop headertext="Drop files here" (onFileDrop)="dropped($event)" 
+    <file-drop dropZoneLabel="Drop files here" (onFileDrop)="dropped($event)" 
     (onFileOver)="fileOver($event)" (onFileLeave)="fileLeave($event)">
-        <span>optional content (don't set headertext then)</span>
+        <span>optional content (don't set dropZoneLabel then)</span>
     </file-drop>
     <div class="upload-table">
         <table class="table">
@@ -143,12 +143,12 @@ Name  | Description | Example |
 (onFileDrop)  | On drop function called after the files are read | (onFileDrop)="dropped($event)"
 (onFileOver)  | On drop over function| (onFileOver)="fileOver($event)"
 (onFileLeave)  | On drop leave function| (onFileLeave)="fileLeave($event)"
-headertext  | Text to be displayed inside the drop box | headertext="Drop files here"
-customstyle  | Custom style class name to be used on the "drop-zone" area | customstyle="my-style"
-customContentStyle  | Custom style class name to be used for the content area | customContentStyle="my-style"
-[disableIf]  | Conditionally disable the dropzone  | [disableIf]="condition"
-showBrowseBtn  | Whether browse file button should be shown  | showBrowseBtn="true"
-customBtnStyling | Custom style class/es to be used for the button | customBtnStyling="my-style"
+dropZoneLabel  | Text to be displayed inside the drop box | dropZoneLabel="Drop files here"
+dropZoneClassName  | Custom style class name(s) to be used on the "drop-zone" area | dropZoneClassName="my-style"
+contentClassName  | Custom style class name(s) to be used for the content area | contentClassName="my-style"
+\[disabled\]  | Conditionally disable the dropzone  | \[disabled\]="condition"
+\[showBrowseBtn\]  | Whether browse file button should be shown  | \[showBrowseBtn\]="true"
+browseBtnClassName | Custom style class name(s) to be used for the button | browseBtnClassName="my-style"
 browseBtnLabel  | The label of the browse file button  | browseBtnLabel="Browse files"
 
 ## License

--- a/src/lib/ngx-drop/file-drop.component.html
+++ b/src/lib/ngx-drop/file-drop.component.html
@@ -1,12 +1,14 @@
-<div [className]="customstyle" [class.over]="dragoverflag"
-    (drop)="dropFiles($event)"
-    (dragover)="onDragOver($event)" (dragleave)="onDragLeave($event)">
-    <div [className]="customContentStyle">
+<div [className]="dropZoneClassName"
+     [class.ngx-file-drop__drop-zone--over]="isDraggingOverDropZone"
+     (drop)="dropFiles($event)"
+     (dragover)="onDragOver($event)"
+     (dragleave)="onDragLeave($event)">
+    <div [className]="contentClassName">
         <ng-content></ng-content>
-        {{headertext}}
+        <div *ngIf="dropZoneLabel" class="ngx-file-drop__drop-zone-label">{{dropZoneLabel}}</div>
         <div *ngIf="showBrowseBtn">
-            <input type="file" #fileSelector class="ngx-file-drop__file-input" [accept]="accept" (change)="uploadFiles($event)" multiple />
-            <input type="button" [className]="customBtnStyling" value="{{browseBtnLabel}}" (click)="onBrowseButtonClick($event)" />
+            <input type="file" #fileSelector (change)="uploadFiles($event)" multiple class="ngx-file-drop__file-input" />
+            <input type="button" [className]="browseBtnClassName" value="{{browseBtnLabel}}" (click)="onBrowseButtonClick($event)" />
         </div>
     </div>
 </div>

--- a/src/lib/ngx-drop/file-drop.component.html
+++ b/src/lib/ngx-drop/file-drop.component.html
@@ -1,4 +1,5 @@
 <div [className]="dropZoneClassName"
+     [class.over]="isDraggingOverDropZone"
      [class.ngx-file-drop__drop-zone--over]="isDraggingOverDropZone"
      (drop)="dropFiles($event)"
      (dragover)="onDragOver($event)"

--- a/src/lib/ngx-drop/file-drop.component.html
+++ b/src/lib/ngx-drop/file-drop.component.html
@@ -5,8 +5,8 @@
         <ng-content></ng-content>
         {{headertext}}
         <div *ngIf="showBrowseBtn">
-            <input type="file" #fileSelector [accept]="accept" (change)="uploadFiles($event)" multiple style="display: none;" />
+            <input type="file" #fileSelector class="ngx-file-drop__file-input" [accept]="accept" (change)="uploadFiles($event)" multiple />
             <input type="button" [className]="customBtnStyling" value="{{browseBtnLabel}}" (click)="onBrowseButtonClick($event)" />
-        </div>        
+        </div>
     </div>
 </div>

--- a/src/lib/ngx-drop/file-drop.component.html
+++ b/src/lib/ngx-drop/file-drop.component.html
@@ -7,7 +7,7 @@
         <ng-content></ng-content>
         <div *ngIf="dropZoneLabel" class="ngx-file-drop__drop-zone-label">{{dropZoneLabel}}</div>
         <div *ngIf="showBrowseBtn">
-            <input type="file" #fileSelector (change)="uploadFiles($event)" multiple class="ngx-file-drop__file-input" />
+            <input type="file" #fileSelector [accept]="accept" (change)="uploadFiles($event)" multiple class="ngx-file-drop__file-input" />
             <input type="button" [className]="browseBtnClassName" value="{{browseBtnLabel}}" (click)="onBrowseButtonClick($event)" />
         </div>
     </div>

--- a/src/lib/ngx-drop/file-drop.component.scss
+++ b/src/lib/ngx-drop/file-drop.component.scss
@@ -1,20 +1,24 @@
-.drop-zone{
-  margin: auto;
+.ngx-file-drop__drop-zone {
   height: 100px;
+  margin: auto;
   border: 2px dotted #0782d0;
   border-radius: 30px;
 }
 
-.content{
-  color: #0782d0;
-  height: 100px;
-  display: flex;
-  justify-content: center;
-  align-items: center;
+.ngx-file-drop__drop-zone--over {
+  background-color: rgba(147, 147, 147, 0.5);
 }
 
-.over{
-  background-color: rgba(147, 147, 147, 0.5);
+.ngx-file-drop__content {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100px;
+  color: #0782d0;
+}
+
+.ngx-file-drop__drop-zone-label {
+  text-align: center;
 }
 
 .ngx-file-drop__file-input {

--- a/src/lib/ngx-drop/file-drop.component.scss
+++ b/src/lib/ngx-drop/file-drop.component.scss
@@ -1,15 +1,18 @@
-.ngx-file-drop__drop-zone {
+.drop-zone {
+//.ngx-file-drop__drop-zone {
   height: 100px;
   margin: auto;
   border: 2px dotted #0782d0;
   border-radius: 30px;
 }
 
-.ngx-file-drop__drop-zone--over {
+.over {
+//.ngx-file-drop__drop-zone--over {
   background-color: rgba(147, 147, 147, 0.5);
 }
 
-.ngx-file-drop__content {
+.content {
+//.ngx-file-drop__content {
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/lib/ngx-drop/file-drop.component.scss
+++ b/src/lib/ngx-drop/file-drop.component.scss
@@ -16,3 +16,7 @@
 .over{
   background-color: rgba(147, 147, 147, 0.5);
 }
+
+.ngx-file-drop__file-input {
+  display: none;
+}

--- a/src/lib/ngx-drop/file-drop.component.ts
+++ b/src/lib/ngx-drop/file-drop.component.ts
@@ -24,21 +24,62 @@ export class FileComponent implements OnDestroy {
 
   @Input()
   public accept: string = '*';
+
   @Input()
   public dropZoneLabel: string = '';
+  /** @deprecated Will be removed in the next major version. Use `dropZoneLabel` instead. */
+  public get headertext(): string { return this.dropZoneLabel; }
+  /** @deprecated Will be removed in the next major version. Use `dropZoneLabel` instead. */
+  @Input()
+  public set headertext(value: string) {
+    this.dropZoneLabel = value;
+  }
+
   @Input()
   public dropZoneClassName: string = 'ngx-file-drop__drop-zone';
+  /** @deprecated Will be removed in the next major version. Use `dropZoneClassName` instead. */
+  public get customstyle(): string { return this.dropZoneClassName; }
+  /** @deprecated Will be removed in the next major version. Use `dropZoneClassName` instead. */
+  @Input()
+  public set customstyle(value: string) {
+    this.dropZoneClassName = value;
+  }
+
   @Input()
   public contentClassName: string = 'ngx-file-drop__content';
+  /** @deprecated Will be removed in the next major version. Use `contentClassName` instead. */
+  public get customContentStyle(): string { return this.contentClassName; }
+  /** @deprecated Will be removed in the next major version. Use `contentClassName` instead. */
+  @Input()
+  public set customContentStyle(value: string) {
+    this.contentClassName = value;
+  }
+
   public get disabled(): boolean { return this._disabled; }
   @Input()
   public set disabled(value: boolean) {
     this._disabled = (value != null && `${value}` !== 'false');
   }
+  /** @deprecated Will be removed in the next major version. Use `disabled` instead. */
+  public get disableIf(): boolean { return this.disabled; }
+  /** @deprecated Will be removed in the next major version. Use `disabled` instead. */
+  @Input()
+  public set disableIf(value: boolean) {
+    this.disabled = value;
+  }
+
   @Input()
   public showBrowseBtn: boolean = false;
   @Input()
   public browseBtnClassName: string = 'btn btn-primary btn-xs ngx-file-drop__browse-btn';
+  /** @deprecated Will be removed in the next major version. Use `browseBtnClassName` instead. */
+  public get customBtnStyling(): string { return this.browseBtnClassName; }
+  /** @deprecated Will be removed in the next major version. Use `browseBtnClassName` instead. */
+  @Input()
+  public set customBtnStyling(value: string) {
+    this.browseBtnClassName = value;
+  }
+
   @Input()
   public browseBtnLabel: string = 'Browse files';
 

--- a/src/lib/ngx-drop/file-drop.component.ts
+++ b/src/lib/ngx-drop/file-drop.component.ts
@@ -36,7 +36,7 @@ export class FileComponent implements OnDestroy {
   }
 
   @Input()
-  public dropZoneClassName: string = 'ngx-file-drop__drop-zone';
+  public dropZoneClassName: string = 'ngx-file-drop__drop-zone drop-zone';
   /** @deprecated Will be removed in the next major version. Use `dropZoneClassName` instead. */
   public get customstyle(): string { return this.dropZoneClassName; }
   /** @deprecated Will be removed in the next major version. Use `dropZoneClassName` instead. */
@@ -46,7 +46,7 @@ export class FileComponent implements OnDestroy {
   }
 
   @Input()
-  public contentClassName: string = 'ngx-file-drop__content';
+  public contentClassName: string = 'ngx-file-drop__content content';
   /** @deprecated Will be removed in the next major version. Use `contentClassName` instead. */
   public get customContentStyle(): string { return this.contentClassName; }
   /** @deprecated Will be removed in the next major version. Use `contentClassName` instead. */


### PR DESCRIPTION
This is based on https://github.com/georgipeltekov/ngx-file-drop/pull/131 and goes a bit further by refactoring the code to use a more consistent naming scheme for exported properties as well as for class internal variables.

Obsolete code has been removed. `stash` does not seem to be used for anything really (?).

These changes would warrant a MAJOR version change since the introduced changes are **not** backwards compatible.