### PR TITLE
Converted FileDrop into a FileDropDirective. 

### DIFF
--- a/src/lib/ngx-drop/file-drop.component.html
+++ b/src/lib/ngx-drop/file-drop.component.html
@@ -1,14 +1,10 @@
-<div [className]="dropZoneClassName"
-     [class.ngx-file-drop__drop-zone--over]="isDraggingOverDropZone"
-     (drop)="dropFiles($event)"
-     (dragover)="onDragOver($event)"
-     (dragleave)="onDragLeave($event)">
+<div [className]="dropZoneClassName" fdFileDrop (fdOnFileOver)="onFileOver.emit($event)"
+    (fdOnFileLeave)="onFileLeave.emit($event)" (fdOnFileDrop)="onFileDrop.emit($event)"
+    [fdDropZoneClassName]="dropZoneFileOverClassName" [fdAccept]="accept" [fdDisabled]="disabled">
     <div [className]="contentClassName">
         <ng-content></ng-content>
         <div *ngIf="dropZoneLabel" class="ngx-file-drop__drop-zone-label">{{dropZoneLabel}}</div>
-        <input type="file" #fileSelector [accept]="accept" (change)="uploadFiles($event)" [multiple]="multiple" class="ngx-file-drop__file-input" />
-        <div *ngIf="showBrowseBtn">
-            <input type="button" [className]="browseBtnClassName" value="{{browseBtnLabel}}" (click)="onBrowseButtonClick($event)" />
-        </div>
+        <file-drop-selector [accept]="accept" [multiple]="multiple" [showBrowseBtn]="showBrowseBtn"
+            [browseBtnClassName]="browseBtnClassName" [browseBtnLabel]="browseBtnLabel"></file-drop-selector>
     </div>
 </div>

--- a/src/lib/ngx-drop/file-drop.component.ts
+++ b/src/lib/ngx-drop/file-drop.component.ts
@@ -1,27 +1,13 @@
-import {
-  Component,
-  Input,
-  Output,
-  EventEmitter,
-  NgZone,
-  OnDestroy,
-  Renderer2,
-  ViewChild,
-  ElementRef
-} from '@angular/core';
-import { timer, Subscription } from 'rxjs';
+import { Component, Input, Output, EventEmitter } from '@angular/core';
 
-import { UploadFile } from './upload-file.model';
 import { UploadEvent } from './upload-event.model';
-import { FileSystemFileEntry, FileSystemEntry, FileSystemDirectoryEntry } from './dom.types';
 
 @Component({
   selector: 'file-drop',
   templateUrl: './file-drop.component.html',
-  styleUrls: ['./file-drop.component.scss'],
+  styleUrls: ['./file-drop.component.scss']
 })
-export class FileComponent implements OnDestroy {
-
+export class FileComponent {
   @Input()
   public accept: string = '*';
 
@@ -35,279 +21,29 @@ export class FileComponent implements OnDestroy {
   public dropZoneClassName: string = 'ngx-file-drop__drop-zone';
 
   @Input()
+  public dropZoneFileOverClassName: string = 'ngx-file-drop__drop-zone--over';
+
+  @Input()
   public contentClassName: string = 'ngx-file-drop__content';
 
-  public get disabled(): boolean { return this._disabled; }
   @Input()
-  public set disabled(value: boolean) {
-    this._disabled = (value != null && `${value}` !== 'false');
-  }
+  public disabled = false;
 
   @Input()
   public showBrowseBtn: boolean = false;
   @Input()
-  public browseBtnClassName: string = 'btn btn-primary btn-xs ngx-file-drop__browse-btn';
+  public browseBtnClassName: string =
+    'btn btn-primary btn-xs ngx-file-drop__browse-btn';
 
   @Input()
   public browseBtnLabel: string = 'Browse files';
 
   @Output()
-  public onFileDrop: EventEmitter<UploadEvent> = new EventEmitter<UploadEvent>();
+  public onFileDrop: EventEmitter<UploadEvent> = new EventEmitter<
+    UploadEvent
+  >();
   @Output()
   public onFileOver: EventEmitter<any> = new EventEmitter<any>();
   @Output()
   public onFileLeave: EventEmitter<any> = new EventEmitter<any>();
-
-  @ViewChild('fileSelector')
-  public fileSelector: ElementRef;
-
-  public isDraggingOverDropZone: boolean = false;
-
-  private globalDraggingInProgress: boolean = false;
-  private globalDragStartListener: () => void;
-  private globalDragEndListener: () => void;
-
-  private files: UploadFile[] = [];
-  private numOfActiveReadEntries: number = 0;
-
-  private helperFormEl: HTMLFormElement | null = null;
-  private fileInputPlaceholderEl: HTMLDivElement | null = null;
-
-  private dropEventTimerSubscription: Subscription | null = null;
-
-  private _disabled: boolean = false;
-
-  constructor(
-    private zone: NgZone,
-    private renderer: Renderer2
-  ) {
-    this.globalDragStartListener = this.renderer.listen('document', 'dragstart', (evt: Event) => {
-      this.globalDraggingInProgress = true;
-    });
-    this.globalDragEndListener = this.renderer.listen('document', 'dragend', (evt: Event) => {
-      this.globalDraggingInProgress = false;
-    });
-  }
-
-  public ngOnDestroy(): void {
-    if (this.dropEventTimerSubscription) {
-      this.dropEventTimerSubscription.unsubscribe();
-      this.dropEventTimerSubscription = null;
-    }
-    this.globalDragStartListener();
-    this.globalDragEndListener();
-    this.files = [];
-    this.helperFormEl = null;
-    this.fileInputPlaceholderEl = null;
-  }
-
-  public onDragOver(event: Event): void {
-    if (!this.isDropzoneDisabled()) {
-      if (!this.isDraggingOverDropZone) {
-        this.isDraggingOverDropZone = true;
-        this.onFileOver.emit(event);
-      }
-      this.preventAndStop(event);
-    }
-  }
-
-  public onDragLeave(event: Event): void {
-    if (!this.isDropzoneDisabled()) {
-      if (this.isDraggingOverDropZone) {
-        this.isDraggingOverDropZone = false;
-        this.onFileLeave.emit(event);
-      }
-      this.preventAndStop(event);
-    }
-  }
-
-  public dropFiles(event: DragEvent): void {
-    if (!this.isDropzoneDisabled()) {
-      this.isDraggingOverDropZone = false;
-      if (event.dataTransfer) {
-        event.dataTransfer.dropEffect = 'copy';
-        let items: FileList | DataTransferItemList;
-        if (event.dataTransfer.items) {
-          items = event.dataTransfer.items;
-        } else {
-          items = event.dataTransfer.files;
-        }
-        this.preventAndStop(event);
-        this.checkFiles(items);
-      }
-    }
-  }
-
-  public onBrowseButtonClick(event?: MouseEvent): void {
-    if (this.fileSelector && this.fileSelector.nativeElement) {
-      (this.fileSelector.nativeElement as HTMLInputElement).click();
-    }
-  }
-
-  /**
-   * Processes the change event of the file input and adds the given files.
-   * @param Event event
-   */
-  public uploadFiles(event: Event): void {
-    if (!this.isDropzoneDisabled()) {
-      if (event.target) {
-        const items = (event.target as HTMLInputElement).files || ([] as any);
-        this.checkFiles(items);
-        this.resetFileInput();
-      }
-    }
-  }
-
-  private checkFiles(items: FileList | DataTransferItemList): void {
-    for (let i = 0; i < items.length; i++) {
-      const item = items[i];
-      let entry: FileSystemEntry | null = null;
-      if (this.canGetAsEntry(item)) {
-        entry = item.webkitGetAsEntry();
-      }
-
-      if (!entry) {
-        if (item) {
-          const fakeFileEntry: FileSystemFileEntry = {
-            name: (item as File).name,
-            isDirectory: false,
-            isFile: true,
-            file: (callback: (filea: File) => void): void => {
-              callback(item as File);
-            },
-          };
-          const toUpload: UploadFile = new UploadFile(fakeFileEntry.name, fakeFileEntry);
-          this.addToQueue(toUpload);
-        }
-
-      } else {
-        if (entry.isFile) {
-          const toUpload: UploadFile = new UploadFile(entry.name, entry);
-          this.addToQueue(toUpload);
-
-        } else if (entry.isDirectory) {
-          this.traverseFileTree(entry, entry.name);
-        }
-      }
-    }
-
-    if (this.dropEventTimerSubscription) {
-      this.dropEventTimerSubscription.unsubscribe();
-    }
-    this.dropEventTimerSubscription = timer(200, 200)
-      .subscribe(() => {
-        if (this.files.length > 0 && this.numOfActiveReadEntries === 0) {
-          this.onFileDrop.emit(new UploadEvent(this.files));
-          this.files = [];
-        }
-      });
-  }
-
-  private traverseFileTree(item: FileSystemEntry, path: string): void {
-    if (item.isFile) {
-      const toUpload: UploadFile = new UploadFile(path, item);
-      this.files.push(toUpload);
-
-    } else {
-      path = path + '/';
-      const dirReader = (item as FileSystemDirectoryEntry).createReader();
-      let entries: FileSystemEntry[] = [];
-
-      const readEntries = () => {
-        this.numOfActiveReadEntries++;
-        dirReader.readEntries((result) => {
-          if (!result.length) {
-            // add empty folders
-            if (entries.length === 0) {
-              const toUpload: UploadFile = new UploadFile(path, item);
-              this.zone.run(() => {
-                this.addToQueue(toUpload);
-              });
-
-            } else {
-              for (let i = 0; i < entries.length; i++) {
-                this.zone.run(() => {
-                  this.traverseFileTree(entries[i], path + entries[i].name);
-                });
-              }
-            }
-
-          } else {
-            // continue with the reading
-            entries = entries.concat(result);
-            readEntries();
-          }
-
-          this.numOfActiveReadEntries--;
-        });
-      };
-
-      readEntries();
-    }
-  }
-
-  /**
-   * Clears any added files from the file input element so the same file can subsequently be added multiple times.
-   */
-  private resetFileInput(): void {
-    if (this.fileSelector && this.fileSelector.nativeElement) {
-      const fileInputEl = this.fileSelector.nativeElement as HTMLInputElement;
-      const fileInputContainerEl = fileInputEl.parentElement;
-      const helperFormEl = this.getHelperFormElement();
-      const fileInputPlaceholderEl = this.getFileInputPlaceholderElement();
-
-      // Just a quick check so we do not mess up the DOM (will never happen though).
-      if (fileInputContainerEl !== helperFormEl) {
-        // Insert the form input placeholder in the DOM before the form input element.
-        this.renderer.insertBefore(fileInputContainerEl, fileInputPlaceholderEl, fileInputEl);
-        // Add the form input as child of the temporary form element, removing the form input from the DOM.
-        this.renderer.appendChild(helperFormEl, fileInputEl);
-        // Reset the form, thus clearing the input element of any files.
-        helperFormEl.reset();
-        // Add the file input back to the DOM in place of the file input placeholder element.
-        this.renderer.insertBefore(fileInputContainerEl, fileInputEl, fileInputPlaceholderEl);
-        // Remove the input placeholder from the DOM
-        this.renderer.removeChild(fileInputContainerEl, fileInputPlaceholderEl);
-      }
-    }
-  }
-
-  /**
-   * Get a cached HTML form element as a helper element to clear the file input element.
-   */
-  private getHelperFormElement(): HTMLFormElement {
-    if (!this.helperFormEl) {
-      this.helperFormEl = this.renderer.createElement('form') as HTMLFormElement;
-    }
-
-    return this.helperFormEl;
-  }
-
-  /**
-   * Get a cached HTML div element to be used as placeholder for the file input element when clearing said element.
-   */
-  private getFileInputPlaceholderElement(): HTMLDivElement {
-    if (!this.fileInputPlaceholderEl) {
-      this.fileInputPlaceholderEl = this.renderer.createElement('div') as HTMLDivElement;
-    }
-
-    return this.fileInputPlaceholderEl;
-  }
-
-  private canGetAsEntry(item: any): item is DataTransferItem {
-    return !!item.webkitGetAsEntry;
-  }
-
-  private isDropzoneDisabled(): boolean {
-    return (this.globalDraggingInProgress || this.disabled);
-  }
-
-  private addToQueue(item: UploadFile): void {
-    this.files.push(item);
-  }
-
-  private preventAndStop(event: Event): void {
-    event.stopPropagation();
-    event.preventDefault();
-  }
 }

--- a/src/lib/ngx-drop/file-drop.directive.ts
+++ b/src/lib/ngx-drop/file-drop.directive.ts
@@ -1,0 +1,281 @@
+import {
+  Directive,
+  ElementRef,
+  EventEmitter,
+  HostListener,
+  Input,
+  NgZone,
+  OnDestroy,
+  Output,
+  Renderer2,
+  ContentChild,
+  AfterContentInit
+} from '@angular/core';
+import { Subscription, timer } from 'rxjs';
+import {
+  FileSystemDirectoryEntry,
+  FileSystemEntry,
+  FileSystemFileEntry
+} from './dom.types';
+import { UploadEvent } from './upload-event.model';
+import { UploadFile } from './upload-file.model';
+import { FileSelector } from '../ngx-file-selector/file-drop-selector.component';
+@Directive({
+  selector: '[fdFileDrop]'
+})
+export class FileDropDirective implements AfterContentInit, OnDestroy {
+  @Input('fdAccept')
+  public accept: string = '*';
+
+  @Input('fdDropZoneClassName')
+  public dropZoneClassName: string = 'ngx-file-drop__drop-zone';
+
+  public get disabled(): boolean {
+    return this._disabled;
+  }
+  @Input('fdDisabled')
+  public set disabled(value: boolean) {
+    this._disabled = value != null && `${value}` !== 'false';
+  }
+
+  @Output('fdOnFileDrop')
+  public onFileDrop: EventEmitter<UploadEvent> = new EventEmitter<
+    UploadEvent
+  >();
+  @Output('fdOnFileOver')
+  public onFileOver: EventEmitter<any> = new EventEmitter<any>();
+  @Output('fdOnFileLeave')
+  public onFileLeave: EventEmitter<any> = new EventEmitter<any>();
+
+  @ContentChild(FileSelector)
+  fileSelector?: FileSelector;
+
+  private _isDraggingOverDropZone = false;
+  get isDraggingOverDropZone() {
+    return this._isDraggingOverDropZone;
+  }
+  set isDraggingOverDropZone(value: boolean) {
+    this._isDraggingOverDropZone = value;
+
+    if (value === true) {
+      this.renderer.addClass(
+        this.element.nativeElement,
+        this.dropZoneClassName
+      );
+    } else {
+      this.renderer.removeClass(
+        this.element.nativeElement,
+        this.dropZoneClassName
+      );
+    }
+  }
+
+  private globalDraggingInProgress: boolean = false;
+  private globalDragStartListener: () => void;
+  private globalDragEndListener: () => void;
+
+  private files: UploadFile[] = [];
+  private numOfActiveReadEntries: number = 0;
+
+  private dropEventTimerSubscription: Subscription | null = null;
+
+  private _disabled: boolean = false;
+
+  constructor(
+    private zone: NgZone,
+    private renderer: Renderer2,
+    private element: ElementRef
+  ) {
+    this.globalDragStartListener = this.renderer.listen(
+      'document',
+      'dragstart',
+      () => {
+        this.globalDraggingInProgress = true;
+      }
+    );
+    this.globalDragEndListener = this.renderer.listen(
+      'document',
+      'dragend',
+      () => {
+        this.globalDraggingInProgress = false;
+      }
+    );
+  }
+
+  // subscribe to the file selector input changes if the file selector exists.
+  ngAfterContentInit(): void {
+    if (this.fileSelector) {
+      this.fileSelector.onFileInputChange.subscribe((c: Event) =>
+        this.uploadFiles(c)
+      );
+    }
+  }
+
+  public ngOnDestroy(): void {
+    if (this.dropEventTimerSubscription) {
+      this.dropEventTimerSubscription.unsubscribe();
+      this.dropEventTimerSubscription = null;
+    }
+    this.globalDragStartListener();
+    this.globalDragEndListener();
+    this.files = [];
+    if (this.fileSelector) {
+      this.fileSelector.onFileInputChange.unsubscribe();
+    }
+  }
+
+  @HostListener('dragover', ['$event'])
+  public onDragOver(event: Event): void {
+    if (!this.isDropzoneDisabled()) {
+      if (!this.isDraggingOverDropZone) {
+        this.isDraggingOverDropZone = true;
+        this.onFileOver.emit(event);
+      }
+      this.preventAndStop(event);
+    }
+  }
+
+  @HostListener('dragleave', ['$event'])
+  public onDragLeave(event: Event): void {
+    if (!this.isDropzoneDisabled()) {
+      if (this.isDraggingOverDropZone) {
+        this.isDraggingOverDropZone = false;
+        this.onFileLeave.emit(event);
+      }
+      this.preventAndStop(event);
+    }
+  }
+
+  @HostListener('drop', ['$event'])
+  public dropFiles(event: DragEvent): void {
+    if (!this.isDropzoneDisabled()) {
+      this.isDraggingOverDropZone = false;
+      if (event.dataTransfer) {
+        event.dataTransfer.dropEffect = 'copy';
+        let items: FileList | DataTransferItemList;
+        if (event.dataTransfer.items) {
+          items = event.dataTransfer.items;
+        } else {
+          items = event.dataTransfer.files;
+        }
+        this.preventAndStop(event);
+        this.checkFiles(items);
+      }
+    }
+  }
+
+  /**
+   * Processes the change event of the file input and adds the given files.
+   * @param Event event
+   */
+  public uploadFiles(event: Event): void {
+    if (!this.isDropzoneDisabled()) {
+      if (event.target) {
+        const items = (event.target as HTMLInputElement).files || ([] as any);
+        this.checkFiles(items);
+      }
+    }
+  }
+
+  private checkFiles(items: FileList | DataTransferItemList): void {
+    for (let i = 0; i < items.length; i++) {
+      const item = items[i];
+      let entry: FileSystemEntry | null = null;
+      if (this.canGetAsEntry(item)) {
+        entry = item.webkitGetAsEntry();
+      }
+
+      if (!entry) {
+        if (item) {
+          const fakeFileEntry: FileSystemFileEntry = {
+            name: (item as File).name,
+            isDirectory: false,
+            isFile: true,
+            file: (callback: (filea: File) => void): void => {
+              callback(item as File);
+            }
+          };
+          const toUpload: UploadFile = new UploadFile(
+            fakeFileEntry.name,
+            fakeFileEntry
+          );
+          this.addToQueue(toUpload);
+        }
+      } else {
+        if (entry.isFile) {
+          const toUpload: UploadFile = new UploadFile(entry.name, entry);
+          this.addToQueue(toUpload);
+        } else if (entry.isDirectory) {
+          this.traverseFileTree(entry, entry.name);
+        }
+      }
+    }
+
+    if (this.dropEventTimerSubscription) {
+      this.dropEventTimerSubscription.unsubscribe();
+    }
+    this.dropEventTimerSubscription = timer(200, 200).subscribe(() => {
+      if (this.files.length > 0 && this.numOfActiveReadEntries === 0) {
+        this.onFileDrop.emit(new UploadEvent(this.files));
+        this.files = [];
+      }
+    });
+  }
+
+  private traverseFileTree(item: FileSystemEntry, path: string): void {
+    if (item.isFile) {
+      const toUpload: UploadFile = new UploadFile(path, item);
+      this.files.push(toUpload);
+    } else {
+      path = path + '/';
+      const dirReader = (item as FileSystemDirectoryEntry).createReader();
+      let entries: FileSystemEntry[] = [];
+
+      const readEntries = () => {
+        this.numOfActiveReadEntries++;
+        dirReader.readEntries(result => {
+          if (!result.length) {
+            // add empty folders
+            if (entries.length === 0) {
+              const toUpload: UploadFile = new UploadFile(path, item);
+              this.zone.run(() => {
+                this.addToQueue(toUpload);
+              });
+            } else {
+              for (let i = 0; i < entries.length; i++) {
+                this.zone.run(() => {
+                  this.traverseFileTree(entries[i], path + entries[i].name);
+                });
+              }
+            }
+          } else {
+            // continue with the reading
+            entries = entries.concat(result);
+            readEntries();
+          }
+
+          this.numOfActiveReadEntries--;
+        });
+      };
+
+      readEntries();
+    }
+  }
+
+  private canGetAsEntry(item: any): item is DataTransferItem {
+    return !!item.webkitGetAsEntry;
+  }
+
+  private isDropzoneDisabled(): boolean {
+    return this.globalDraggingInProgress || this.disabled;
+  }
+
+  private addToQueue(item: UploadFile): void {
+    this.files.push(item);
+  }
+
+  private preventAndStop(event: Event): void {
+    event.stopPropagation();
+    event.preventDefault();
+  }
+}

--- a/src/lib/ngx-drop/file-drop.module.ts
+++ b/src/lib/ngx-drop/file-drop.module.ts
@@ -1,14 +1,14 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import {FileComponent} from './file-drop.component';
+import { FileComponent } from './file-drop.component';
+import { FileDropDirective } from './file-drop.directive';
+import { FileSelector } from '../ngx-file-selector/file-drop-selector.component';
 
 @NgModule({
-  declarations: [
-    FileComponent,
-  ],
-  exports: [FileComponent],
+  declarations: [FileDropDirective, FileComponent, FileSelector],
+  exports: [FileDropDirective, FileComponent, FileSelector],
   imports: [CommonModule],
   providers: [],
-  bootstrap: [FileComponent],
+  bootstrap: [FileComponent]
 })
 export class FileDropModule {}

--- a/src/lib/ngx-file-selector/file-drop-selector.component.html
+++ b/src/lib/ngx-file-selector/file-drop-selector.component.html
@@ -1,0 +1,6 @@
+<input type="file" #fileSelector [accept]="accept" (change)="uploadFiles($event)" [multiple]="multiple"
+    class="ngx-file-drop__file-input" />
+<div *ngIf="showBrowseBtn">
+    <input type="button" [className]="browseBtnClassName" value="{{browseBtnLabel}}"
+        (click)="onBrowseButtonClick($event)" />
+</div>

--- a/src/lib/ngx-file-selector/file-drop-selector.component.scss
+++ b/src/lib/ngx-file-selector/file-drop-selector.component.scss
@@ -1,0 +1,3 @@
+.ngx-file-drop__file-input {
+  display: none;
+}

--- a/src/lib/ngx-file-selector/file-drop-selector.component.ts
+++ b/src/lib/ngx-file-selector/file-drop-selector.component.ts
@@ -1,0 +1,124 @@
+import {
+  Component,
+  Input,
+  ViewChild,
+  ElementRef,
+  Renderer2,
+  OnDestroy,
+  Output,
+  EventEmitter
+} from '@angular/core';
+
+@Component({
+  selector: 'file-drop-selector',
+  templateUrl: './file-drop-selector.component.html',
+  styleUrls: ['./file-drop-selector.component.scss']
+})
+export class FileSelector implements OnDestroy {
+  @Input()
+  public accept: string = '*';
+
+  @Input()
+  public multiple: boolean = true;
+
+  @Input()
+  showBrowseBtn = false;
+
+  @Input()
+  public browseBtnClassName: string =
+    'btn btn-primary btn-xs ngx-file-drop__browse-btn';
+
+  @Input()
+  public browseBtnLabel: string = 'Browse files';
+
+  @Output()
+  public onFileInputChange = new EventEmitter<Event>();
+
+  @ViewChild('fileSelector')
+  public fileSelector: ElementRef;
+
+  private helperFormEl: HTMLFormElement | null = null;
+  private fileInputPlaceholderEl: HTMLDivElement | null = null;
+
+  constructor(private renderer: Renderer2) {}
+
+  ngOnDestroy(): void {
+    this.helperFormEl = null;
+    this.fileInputPlaceholderEl = null;
+  }
+
+  public onBrowseButtonClick(event?: MouseEvent): void {
+    if (this.fileSelector && this.fileSelector.nativeElement) {
+      (this.fileSelector.nativeElement as HTMLInputElement).click();
+    }
+  }
+
+  /**
+   * Propogate the input changed event to be handled by the FileDropDirective.
+   * @param Event event
+   */
+  public uploadFiles(event: Event): void {
+    this.onFileInputChange.emit(event);
+    this.resetFileInput();
+  }
+
+  /**
+   * Clears any added files from the file input element so the same file can subsequently be added multiple times.
+   */
+  private resetFileInput(): void {
+    if (this.fileSelector && this.fileSelector.nativeElement) {
+      const fileInputEl = this.fileSelector.nativeElement as HTMLInputElement;
+      const fileInputContainerEl = fileInputEl.parentElement;
+      const helperFormEl = this.getHelperFormElement();
+      const fileInputPlaceholderEl = this.getFileInputPlaceholderElement();
+
+      // Just a quick check so we do not mess up the DOM (will never happen though).
+      if (fileInputContainerEl !== helperFormEl) {
+        // Insert the form input placeholder in the DOM before the form input element.
+        this.renderer.insertBefore(
+          fileInputContainerEl,
+          fileInputPlaceholderEl,
+          fileInputEl
+        );
+        // Add the form input as child of the temporary form element, removing the form input from the DOM.
+        this.renderer.appendChild(helperFormEl, fileInputEl);
+        // Reset the form, thus clearing the input element of any files.
+        helperFormEl.reset();
+        // Add the file input back to the DOM in place of the file input placeholder element.
+        this.renderer.insertBefore(
+          fileInputContainerEl,
+          fileInputEl,
+          fileInputPlaceholderEl
+        );
+        // Remove the input placeholder from the DOM
+        this.renderer.removeChild(fileInputContainerEl, fileInputPlaceholderEl);
+      }
+    }
+  }
+
+  /**
+   * Get a cached HTML form element as a helper element to clear the file input element.
+   */
+  private getHelperFormElement(): HTMLFormElement {
+    if (!this.helperFormEl) {
+      this.helperFormEl = this.renderer.createElement(
+        'form'
+      ) as HTMLFormElement;
+    }
+
+    return this.helperFormEl;
+  }
+
+  /**
+   * Get a cached HTML div element to be used as placeholder for the file input element when clearing said element.
+   */
+  private getFileInputPlaceholderElement(): HTMLDivElement {
+    if (!this.fileInputPlaceholderEl) {
+      this.fileInputPlaceholderEl = this.renderer.createElement(
+        'div'
+      ) as HTMLDivElement;
+    }
+
+    return this.fileInputPlaceholderEl;
+  }
+}


### PR DESCRIPTION
Wanted the file drop functionality but without any of the styling.  For me, it was a lot easier to work with file drop as a directive, that was I can add it to any div and have a little more flexibility with the styling.  It's a small ease of use improvement, but I can't imagine I'm the only one who would prefer to use it as a directive.

There should be no breaking changes because the FileDrop component keeps the same interface.  I'm not familiar with all of the features, so still needs more review.  This is still a work in progress, I'm submitting as a draft to get some feedback on if this is a direction you'd like to go.  I do think it makes the file drop a little more general purpose.

Changes:
- Most of the file drop functionality was moved into the new FileDropDirective.
- File Selection functionality was moved to a FileSelection component that works with the directive.
- FileDrop component is now a basic implementation of the FileDropDirective and FileSelection component.