### PR TITLE
fix(package): lowering node version requirement to LTS version 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ export class AppComponent {
 <div class="center">
     <ngx-file-drop dropZoneLabel="Drop files here" (onFileDrop)="dropped($event)" 
     (onFileOver)="fileOver($event)" (onFileLeave)="fileLeave($event)">
-        <ng-template let-openFileSelector="openFileSelector">
+        <ng-template ngx-file-drop-content-tmp let-openFileSelector="openFileSelector">
           Optional custom content that replaces the the entire default content.
           <button type="button" (click)="openFileSelector()">Browse Files</button>
         </ng-template>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "repository": "georgipeltekov/ngx-file-drop",
   "engines": {
-    "node": ">= 12.0.0",
+    "node": ">= 10.0.0",
     "npm": ">= 6.9.0"
   },
   "scripts": {


### PR DESCRIPTION
During the update to Angular 8 the node version requirement was set to
version 12.* although the LTS version 10.* is the lowest bound.

fixes #152