### PR TITLE
Fix for #191 ([BUG] dataTransfer.dropEffect doesn't seem to work)

### DIFF
--- a/src/ngx-file-drop/ngx-file-drop.component.ts
+++ b/src/ngx-file-drop/ngx-file-drop.component.ts
@@ -116,15 +116,19 @@ export class NgxFileDropComponent implements OnDestroy {
     this.fileInputPlaceholderEl = null;
   }
 
-  public onDragOver(event: Event): void {
+  public onDragOver(event: DragEvent): void {
     if (this.useDragEnter) {
       this.preventAndStop(event);
-    } else if (!this.isDropzoneDisabled() && !this.useDragEnter) {
+      if (event.dataTransfer) {
+        event.dataTransfer.dropEffect = 'copy';
+      }
+    } else if (!this.isDropzoneDisabled() && !this.useDragEnter && event.dataTransfer) {
       if (!this.isDraggingOverDropZone) {
         this.isDraggingOverDropZone = true;
         this.onFileOver.emit(event);
       }
       this.preventAndStop(event);
+      event.dataTransfer.dropEffect = 'copy';
     }
   }
 
@@ -152,7 +156,6 @@ export class NgxFileDropComponent implements OnDestroy {
     if (!this.isDropzoneDisabled()) {
       this.isDraggingOverDropZone = false;
       if (event.dataTransfer) {
-        event.dataTransfer.dropEffect = 'copy';
         let items: FileList | DataTransferItemList;
         if (event.dataTransfer.items) {
           items = event.dataTransfer.items;


### PR DESCRIPTION
Taking as a reference a fix for a similar issue (https://github.com/transloadit/uppy/commit/e49b61a6b75a5999b9c5be2abcd0a786540ae7ae), this PR should fix the bug where the `dropEffect` is not taking into consideration and an item coming from an external application (ie. Outlook) is deleted due to "move" action instead of "copy".