### PR TITLE
Make FileSystemFileEntry.file() chainable

### DIFF
--- a/src/ngx-file-drop/dom.types.ts
+++ b/src/ngx-file-drop/dom.types.ts
@@ -43,5 +43,5 @@ export interface FileSystemDirectoryEntry extends FileSystemEntry {
 export interface FileSystemFileEntry extends FileSystemEntry {
   isDirectory: false
   isFile: true
-  file(callback: (file: File) => void): void
+  file<T>(callback: (file: File) => T): T
 }

--- a/src/ngx-file-drop/ngx-file-drop.component.ts
+++ b/src/ngx-file-drop/ngx-file-drop.component.ts
@@ -202,9 +202,7 @@ export class NgxFileDropComponent implements OnDestroy {
             name: (item as File).name,
             isDirectory: false,
             isFile: true,
-            file: (callback: (filea: File) => void): void => {
-              callback(item as File);
-            },
+            file: <T>(callback: (filea: File) => T) => callback(item as File),
           };
           const toUpload: NgxFileDropEntry = new NgxFileDropEntry(fakeFileEntry.name, fakeFileEntry);
           this.addToQueue(toUpload);


### PR DESCRIPTION
I didn't quite understand why `FileSystemFileEntry.file()` had to be a callback since `file()` does nothing but call the given function. Because I wanted to use the file in a mapping chain I made it so that `file()` returned whatever the callback returned seeing it as the only option to get the functionality I was looking for while still being backwards compatible. 

So with these few changes you'll be able to do the following:

```ts
 public dropped(files: NgxFileDropEntry[]){
    const uploadRequests: Observable[] = files
    .filter(file => file.fileEntry.isFile)
    .map(file => file.fileEntry as FileSystemFileEntry)
    .map(file => file.file(realFile => {
        const data = new FormData();
        data.append('file', realFile);
        return this.http.post('/api/upload', data);
      })
    );
  }
```